### PR TITLE
feat: Added flattened views of sample details, specimen details and others

### DIFF
--- a/src/gpaslocal/__init__.py
+++ b/src/gpaslocal/__init__.py
@@ -1,2 +1,2 @@
 __version__ = "0.0.1"
-__dbrevision__: str = "5fb8a9b2fea7"
+__dbrevision__: str = "f4183f1d16d9"

--- a/src/gpaslocal/gpas_upload.py
+++ b/src/gpaslocal/gpas_upload.py
@@ -319,6 +319,6 @@ def mutation(
     mut.coverage = mutation.coverage
     mut.prediction = mutation.prediction
     mut.evidence = mutation.evidence
-    mut.evidence_json = mutation.evidence_json # type: ignore
+    mut.evidence_json = mutation.evidence_json  # type: ignore
 
     return mut

--- a/src/gpaslocal/migrations/env.py
+++ b/src/gpaslocal/migrations/env.py
@@ -24,9 +24,19 @@ if config.config_file_name is not None:
 # target_metadata = mymodel.Base.metadata
 target_metadata = Model.metadata
 
-# to keep mypy quiet do an assert
 config.set_main_option("sqlalchemy.url", app_config.DATABASE_URL)
 
+ignored_views = [
+    "alembic_version", 
+    "flattened_sample_details_view",
+    "flattened_specimen_details_view",
+    "flattened_others_view",
+]
+
+def include_object(object, name, type_, reflected, compare_to):
+    if type_ == "table" and name in ignored_views:
+        return False
+    return True
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.
@@ -46,6 +56,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        include_object=include_object,
     )
 
     with context.begin_transaction():
@@ -66,6 +77,7 @@ def run_migrations_online() -> None:
             connection=connection,
             target_metadata=target_metadata,
             render_as_batch=True,
+            include_object=include_object,
         )
 
         with context.begin_transaction():

--- a/src/gpaslocal/migrations/env.py
+++ b/src/gpaslocal/migrations/env.py
@@ -27,16 +27,18 @@ target_metadata = Model.metadata
 config.set_main_option("sqlalchemy.url", app_config.DATABASE_URL)
 
 ignored_views = [
-    "alembic_version", 
+    "alembic_version",
     "flattened_sample_details_view",
     "flattened_specimen_details_view",
     "flattened_others_view",
 ]
 
+
 def include_object(object, name, type_, reflected, compare_to):
     if type_ == "table" and name in ignored_views:
         return False
     return True
+
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.

--- a/src/gpaslocal/migrations/versions/74f145bf0bdc_flatten_specimen_details.py
+++ b/src/gpaslocal/migrations/versions/74f145bf0bdc_flatten_specimen_details.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
     DECLARE
         type_record record;
         -- can not use replace view here as it complains about columns being dropped
-        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_specimen_details_view; CREATE VIEW flattened_specimen_details_view AS SELECT s.id';
+        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_specimen_details_view; CREATE VIEW flattened_specimen_details_view AS SELECT s.id as specimen_id';
         sql_columns TEXT := '';
         sql_joins TEXT := ' FROM specimens s';
         column_alias TEXT;

--- a/src/gpaslocal/migrations/versions/74f145bf0bdc_flatten_specimen_details.py
+++ b/src/gpaslocal/migrations/versions/74f145bf0bdc_flatten_specimen_details.py
@@ -1,0 +1,78 @@
+"""flatten specimen details
+
+Revision ID: 74f145bf0bdc
+Revises: fa75ffba1cf6
+Create Date: 2024-04-08 13:57:37.523477
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '74f145bf0bdc'
+down_revision: Union[str, None] = 'fa75ffba1cf6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE FUNCTION create_flattened_specimen_details_view()
+    RETURNS void AS $$
+    DECLARE
+        type_record record;
+        -- can not use replace view here as it complains about columns being dropped
+        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_specimen_details_view; CREATE VIEW flattened_specimen_details_view AS SELECT s.id';
+        sql_columns TEXT := '';
+        sql_joins TEXT := ' FROM specimens s';
+        column_alias TEXT;
+        value_field TEXT;
+    BEGIN
+        -- Loop through each sample detail type to build the dynamic columns and joins
+        FOR type_record IN SELECT * FROM specimen_detail_types LOOP
+            column_alias := 'sd_' || type_record.code::text;
+            value_field := type_record.value_type::text;
+
+            sql_joins := sql_joins || ' LEFT JOIN specimen_details ' || column_alias || ' ON s.id = ' || column_alias || '.specimen_id AND ' || column_alias || '.specimen_detail_type_code = ' || quote_literal(type_record.code);
+
+            sql_columns := sql_columns || ', ' || column_alias || '.value_' || value_field || ' AS ' || quote_ident(type_record.code);
+        END LOOP;
+
+        -- Combine parts to form the final SQL
+        raise notice 'joins (%)', sql_joins;
+        raise notice 'columns (%)', sql_columns;
+        EXECUTE sql_start || sql_columns || sql_joins;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+    # create the view for the first time
+    op.execute("SELECT create_flattened_specimen_details_view();")
+    # create a function that returns a trigger to update the view
+    op.execute("""
+    CREATE OR REPLACE FUNCTION update_flattened_specimen_details_view()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        PERFORM create_flattened_specimen_details_view();
+        RETURN NULL;
+    END;
+    $$ language 'plpgsql';
+    """)
+    # create a trigger to update the view when a sample is inserted or updated or deleted
+    op.execute("""
+    CREATE TRIGGER update_flattened_specimen_details_view_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON specimen_detail_types
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION update_flattened_specimen_details_view();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+    DROP TRIGGER update_flattened_specimen_details_view_trigger ON samples;
+    DROP FUNCTION update_flattened_specimen_details_view();
+    DROP VIEW flattened_specimen_details_view;
+    DROP FUNCTION create_flattened_specimen_details_view();
+    """)

--- a/src/gpaslocal/migrations/versions/74f145bf0bdc_flatten_specimen_details.py
+++ b/src/gpaslocal/migrations/versions/74f145bf0bdc_flatten_specimen_details.py
@@ -8,18 +8,18 @@ Create Date: 2024-04-08 13:57:37.523477
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '74f145bf0bdc'
-down_revision: Union[str, None] = 'fa75ffba1cf6'
+revision: str = "74f145bf0bdc"
+down_revision: Union[str, None] = "fa75ffba1cf6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute("""
+    op.execute(
+        """
     CREATE OR REPLACE FUNCTION create_flattened_specimen_details_view()
     RETURNS void AS $$
     DECLARE
@@ -47,11 +47,13 @@ def upgrade() -> None:
         EXECUTE sql_start || sql_columns || sql_joins;
     END;
     $$ LANGUAGE plpgsql;
-    """)
+    """
+    )
     # create the view for the first time
     op.execute("SELECT create_flattened_specimen_details_view();")
     # create a function that returns a trigger to update the view
-    op.execute("""
+    op.execute(
+        """
     CREATE OR REPLACE FUNCTION update_flattened_specimen_details_view()
     RETURNS TRIGGER AS $$
     BEGIN
@@ -59,20 +61,25 @@ def upgrade() -> None:
         RETURN NULL;
     END;
     $$ language 'plpgsql';
-    """)
+    """
+    )
     # create a trigger to update the view when a sample is inserted or updated or deleted
-    op.execute("""
+    op.execute(
+        """
     CREATE TRIGGER update_flattened_specimen_details_view_trigger
     AFTER INSERT OR UPDATE OR DELETE ON specimen_detail_types
     FOR EACH STATEMENT
     EXECUTE FUNCTION update_flattened_specimen_details_view();
-    """)
+    """
+    )
 
 
 def downgrade() -> None:
-    op.execute("""
+    op.execute(
+        """
     DROP TRIGGER update_flattened_specimen_details_view_trigger ON samples;
     DROP FUNCTION update_flattened_specimen_details_view();
     DROP VIEW flattened_specimen_details_view;
     DROP FUNCTION create_flattened_specimen_details_view();
-    """)
+    """
+    )

--- a/src/gpaslocal/migrations/versions/f4183f1d16d9_flatten_other_details.py
+++ b/src/gpaslocal/migrations/versions/f4183f1d16d9_flatten_other_details.py
@@ -8,18 +8,18 @@ Create Date: 2024-04-08 15:38:19.812632
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'f4183f1d16d9'
-down_revision: Union[str, None] = '74f145bf0bdc'
+revision: str = "f4183f1d16d9"
+down_revision: Union[str, None] = "74f145bf0bdc"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute("""
+    op.execute(
+        """
     CREATE OR REPLACE FUNCTION create_flattened_others_view()
     RETURNS void AS $$
     DECLARE
@@ -47,11 +47,13 @@ def upgrade() -> None:
         EXECUTE sql_start || sql_columns || sql_joins;
     END;
     $$ LANGUAGE plpgsql;
-    """)
+    """
+    )
     # create the view for the first time
     op.execute("SELECT create_flattened_others_view();")
     # create a function that returns a trigger to update the view
-    op.execute("""
+    op.execute(
+        """
     CREATE OR REPLACE FUNCTION update_flattened_others_view()
     RETURNS TRIGGER AS $$
     BEGIN
@@ -59,20 +61,25 @@ def upgrade() -> None:
         RETURN NULL;
     END;
     $$ language 'plpgsql';
-    """)
+    """
+    )
     # create a trigger to update the view when a sample is inserted or updated or deleted
-    op.execute("""
+    op.execute(
+        """
     CREATE TRIGGER update_flattened_others_view_trigger
     AFTER INSERT OR UPDATE OR DELETE ON other_types
     FOR EACH STATEMENT
     EXECUTE FUNCTION update_flattened_others_view();
-    """)
+    """
+    )
 
 
 def downgrade() -> None:
-    op.execute("""
+    op.execute(
+        """
     DROP TRIGGER update_flattened_others_view_trigger ON samples;
     DROP FUNCTION update_flattened_others_view();
     DROP VIEW flattened_others_view;
     DROP FUNCTION create_flattened_others_view();
-    """)
+    """
+    )

--- a/src/gpaslocal/migrations/versions/f4183f1d16d9_flatten_other_details.py
+++ b/src/gpaslocal/migrations/versions/f4183f1d16d9_flatten_other_details.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
     DECLARE
         type_record record;
         -- can not use replace view here as it complains about columns being dropped
-        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_others_view; CREATE VIEW flattened_others_view AS SELECT a.id';
+        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_others_view; CREATE VIEW flattened_others_view AS SELECT a.id as analysis_id';
         sql_columns TEXT := '';
         sql_joins TEXT := ' FROM analyses a';
         column_alias TEXT;

--- a/src/gpaslocal/migrations/versions/f4183f1d16d9_flatten_other_details.py
+++ b/src/gpaslocal/migrations/versions/f4183f1d16d9_flatten_other_details.py
@@ -1,0 +1,78 @@
+"""flatten other details
+
+Revision ID: f4183f1d16d9
+Revises: 74f145bf0bdc
+Create Date: 2024-04-08 15:38:19.812632
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f4183f1d16d9'
+down_revision: Union[str, None] = '74f145bf0bdc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE FUNCTION create_flattened_others_view()
+    RETURNS void AS $$
+    DECLARE
+        type_record record;
+        -- can not use replace view here as it complains about columns being dropped
+        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_others_view; CREATE VIEW flattened_others_view AS SELECT a.id';
+        sql_columns TEXT := '';
+        sql_joins TEXT := ' FROM analyses a';
+        column_alias TEXT;
+        value_field TEXT;
+    BEGIN
+        -- Loop through each sample detail type to build the dynamic columns and joins
+        FOR type_record IN SELECT * FROM other_types LOOP
+            column_alias := 'o_' || type_record.code::text;
+            value_field := type_record.value_type::text;
+
+            sql_joins := sql_joins || ' LEFT JOIN others ' || column_alias || ' ON a.id = ' || column_alias || '.analysis_id AND ' || column_alias || '.other_type_code = ' || quote_literal(type_record.code);
+
+            sql_columns := sql_columns || ', ' || column_alias || '.value_' || value_field || ' AS ' || quote_ident(type_record.code);
+        END LOOP;
+
+        -- Combine parts to form the final SQL
+        raise notice 'joins (%)', sql_joins;
+        raise notice 'columns (%)', sql_columns;
+        EXECUTE sql_start || sql_columns || sql_joins;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+    # create the view for the first time
+    op.execute("SELECT create_flattened_others_view();")
+    # create a function that returns a trigger to update the view
+    op.execute("""
+    CREATE OR REPLACE FUNCTION update_flattened_others_view()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        PERFORM create_flattened_others_view();
+        RETURN NULL;
+    END;
+    $$ language 'plpgsql';
+    """)
+    # create a trigger to update the view when a sample is inserted or updated or deleted
+    op.execute("""
+    CREATE TRIGGER update_flattened_others_view_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON other_types
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION update_flattened_others_view();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+    DROP TRIGGER update_flattened_others_view_trigger ON samples;
+    DROP FUNCTION update_flattened_others_view();
+    DROP VIEW flattened_others_view;
+    DROP FUNCTION create_flattened_others_view();
+    """)

--- a/src/gpaslocal/migrations/versions/fa75ffba1cf6_flatten_sample_details.py
+++ b/src/gpaslocal/migrations/versions/fa75ffba1cf6_flatten_sample_details.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
     DECLARE
         type_record record;
         -- can not use replace view here as it complains about columns being dropped
-        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_sample_details_view; CREATE VIEW flattened_sample_details_view AS SELECT s.id';
+        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_sample_details_view; CREATE VIEW flattened_sample_details_view AS SELECT s.id as sample_id';
         sql_columns TEXT := '';
         sql_joins TEXT := ' FROM samples s';
         column_alias TEXT;

--- a/src/gpaslocal/migrations/versions/fa75ffba1cf6_flatten_sample_details.py
+++ b/src/gpaslocal/migrations/versions/fa75ffba1cf6_flatten_sample_details.py
@@ -1,0 +1,78 @@
+"""flatten sample details
+
+Revision ID: fa75ffba1cf6
+Revises: 5fb8a9b2fea7
+Create Date: 2024-04-08 11:30:13.597551
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'fa75ffba1cf6'
+down_revision: Union[str, None] = '5fb8a9b2fea7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE FUNCTION create_flattened_sample_details_view()
+    RETURNS void AS $$
+    DECLARE
+        type_record record;
+        -- can not use replace view here as it complains about columns being dropped
+        sql_start TEXT := 'DROP VIEW IF EXISTS flattened_sample_details_view; CREATE VIEW flattened_sample_details_view AS SELECT s.id';
+        sql_columns TEXT := '';
+        sql_joins TEXT := ' FROM samples s';
+        column_alias TEXT;
+        value_field TEXT;
+    BEGIN
+        -- Loop through each sample detail type to build the dynamic columns and joins
+        FOR type_record IN SELECT * FROM sample_detail_types LOOP
+            column_alias := 'sd_' || type_record.code::text;
+            value_field := type_record.value_type::text;
+
+            sql_joins := sql_joins || ' LEFT JOIN sample_details ' || column_alias || ' ON s.id = ' || column_alias || '.sample_id AND ' || column_alias || '.sample_detail_type_code = ' || quote_literal(type_record.code);
+
+            sql_columns := sql_columns || ', ' || column_alias || '.value_' || value_field || ' AS ' || quote_ident(type_record.code);
+        END LOOP;
+
+        -- Combine parts to form the final SQL
+        raise notice 'joins (%)', sql_joins;
+        raise notice 'columns (%)', sql_columns;
+        EXECUTE sql_start || sql_columns || sql_joins;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+    # create the view for the first time
+    op.execute("SELECT create_flattened_sample_details_view();")
+    # create a function that returns a trigger to update the view
+    op.execute("""
+    CREATE OR REPLACE FUNCTION update_flattened_sample_details_view()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        PERFORM create_flattened_sample_details_view();
+        RETURN NULL;
+    END;
+    $$ language 'plpgsql';
+    """)
+    # create a trigger to update the view when a sample is inserted or updated or deleted
+    op.execute("""
+    CREATE TRIGGER update_flattened_sample_details_view_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON sample_detail_types
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION update_flattened_sample_details_view();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+    DROP TRIGGER update_flattened_sample_details_view_trigger ON samples;
+    DROP FUNCTION update_flattened_sample_details_view();
+    DROP VIEW flattened_sample_details_view;
+    DROP FUNCTION create_flattened_sample_details_view();
+    """)

--- a/src/gpaslocal/migrations/versions/fa75ffba1cf6_flatten_sample_details.py
+++ b/src/gpaslocal/migrations/versions/fa75ffba1cf6_flatten_sample_details.py
@@ -8,18 +8,18 @@ Create Date: 2024-04-08 11:30:13.597551
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'fa75ffba1cf6'
-down_revision: Union[str, None] = '5fb8a9b2fea7'
+revision: str = "fa75ffba1cf6"
+down_revision: Union[str, None] = "5fb8a9b2fea7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute("""
+    op.execute(
+        """
     CREATE OR REPLACE FUNCTION create_flattened_sample_details_view()
     RETURNS void AS $$
     DECLARE
@@ -47,11 +47,13 @@ def upgrade() -> None:
         EXECUTE sql_start || sql_columns || sql_joins;
     END;
     $$ LANGUAGE plpgsql;
-    """)
+    """
+    )
     # create the view for the first time
     op.execute("SELECT create_flattened_sample_details_view();")
     # create a function that returns a trigger to update the view
-    op.execute("""
+    op.execute(
+        """
     CREATE OR REPLACE FUNCTION update_flattened_sample_details_view()
     RETURNS TRIGGER AS $$
     BEGIN
@@ -59,20 +61,25 @@ def upgrade() -> None:
         RETURN NULL;
     END;
     $$ language 'plpgsql';
-    """)
+    """
+    )
     # create a trigger to update the view when a sample is inserted or updated or deleted
-    op.execute("""
+    op.execute(
+        """
     CREATE TRIGGER update_flattened_sample_details_view_trigger
     AFTER INSERT OR UPDATE OR DELETE ON sample_detail_types
     FOR EACH STATEMENT
     EXECUTE FUNCTION update_flattened_sample_details_view();
-    """)
+    """
+    )
 
 
 def downgrade() -> None:
-    op.execute("""
+    op.execute(
+        """
     DROP TRIGGER update_flattened_sample_details_view_trigger ON samples;
     DROP FUNCTION update_flattened_sample_details_view();
     DROP VIEW flattened_sample_details_view;
     DROP FUNCTION create_flattened_sample_details_view();
-    """)
+    """
+    )


### PR DESCRIPTION
PostgreSQL views don't support dynamic fields. So to handle flattening of the sample details, specimen details and others, a stored procedure is used to create the view. The stored procedure is then called by a trigger on update, delete or insert on the relevant lookup type tables

Views are detected as tables by alembic, so when autogenerate is run it will detect a difference between the database and the models. This is why the ignored_views is needed.

These views will probably not be used directly by the users, but will support the creation of views they will use. Still waiting on users to define what they want out of the system. We will probably need to also do something similar with the spike (chemicals added during sequencing) data, but waiting on how this should be handled

